### PR TITLE
Opinion file, build.gradle, and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.classpath
+/.project
+/.settings/
+/build
+bin
+*.sla

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,11 @@
+apply from: "$rootProject.projectDir/gradle/distributableGhidraModule.gradle"
+apply from: "$rootProject.projectDir/gradle/javaProject.gradle"
+apply from: "$rootProject.projectDir/gradle/jacocoProject.gradle"
+apply from: "$rootProject.projectDir/gradle/javaTestProject.gradle"
+apply from: "$rootProject.projectDir/gradle/processorProject.gradle"
+apply plugin: 'eclipse'
+eclipse.project.name = 'Processors WE32100'
+
+dependencies {
+	compile project(':Base')
+}

--- a/data/languages/WE.opinion
+++ b/data/languages/WE.opinion
@@ -1,0 +1,5 @@
+<opinions>
+	<constraint loader="Common Object File Format (COFF)" compilerSpecID="default">
+		<constraint primary="28673" processor="WE" endian="little" size="32" />
+	</constraint>
+</opinions>


### PR DESCRIPTION
* Adds an opinion file to make loading COFF binaries a little easier.
* Adds a build.gradle file for Eclipse+Ghidra integration.
* Adds a .gitignore file.